### PR TITLE
fix: resolve 98 test failures across 3 bug categories

### DIFF
--- a/web-app/src/components/__tests__/AgentEditor.test.tsx
+++ b/web-app/src/components/__tests__/AgentEditor.test.tsx
@@ -26,6 +26,9 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2>{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
   DialogFooter: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/web-app/src/components/__tests__/AgentTeamBuilder.test.tsx
+++ b/web-app/src/components/__tests__/AgentTeamBuilder.test.tsx
@@ -71,6 +71,9 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2>{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
   DialogFooter: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/web-app/src/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/web-app/src/components/ui/__tests__/dropdown-menu.test.tsx
@@ -3,7 +3,6 @@ import { describe, it, expect, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import {
   DropdownMenu,
-  DropdownMenuPortal,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -47,25 +46,6 @@ describe('DropdownMenu Components', () => {
       )
       
       // Check that the dropdown renders without errors when modal={false}
-      const trigger = screen.getByRole('button', { name: 'Open' })
-      expect(trigger).toBeInTheDocument()
-    })
-  })
-
-  describe('DropdownMenuPortal', () => {
-    it('renders DropdownMenuPortal with correct data-slot', () => {
-      render(
-        <DropdownMenu>
-          <DropdownMenuTrigger>Open</DropdownMenuTrigger>
-          <DropdownMenuPortal>
-            <DropdownMenuContent>
-              <DropdownMenuItem>Item</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenuPortal>
-        </DropdownMenu>
-      )
-      
-      // Check that the dropdown renders without errors with portal
       const trigger = screen.getByRole('button', { name: 'Open' })
       expect(trigger).toBeInTheDocument()
     })

--- a/web-app/src/containers/__tests__/ThreadList.test.tsx
+++ b/web-app/src/containers/__tests__/ThreadList.test.tsx
@@ -80,6 +80,7 @@ vi.mock('@/components/ui/context-menu', () => ({
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,

--- a/web-app/src/containers/dialogs/__tests__/AddEditAssistant.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/AddEditAssistant.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2 data-testid="dialog-title">{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 

--- a/web-app/src/containers/dialogs/__tests__/AddEditMCPServer.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/AddEditMCPServer.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2 data-testid="dialog-title">{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 

--- a/web-app/src/containers/dialogs/__tests__/AddProjectDialog.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/AddProjectDialog.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2 data-testid="dialog-title">{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 

--- a/web-app/src/containers/dialogs/__tests__/AddProviderDialog.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/AddProviderDialog.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => (
     <h2 data-testid="dialog-title">{children}</h2>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogClose: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,

--- a/web-app/src/lib/date-group.ts
+++ b/web-app/src/lib/date-group.ts
@@ -22,8 +22,11 @@ function startOfDay(date: Date): Date {
 export function getDateGroup(date: Date | string | number): DateGroup {
   const now = startOfDay(new Date())
   const target = startOfDay(new Date(date))
-  const diffDays = Math.floor(
-    (now.getTime() - target.getTime()) / MS_PER_DAY,
+  // Use UTC to avoid DST-related off-by-one errors in day difference
+  const diffDays = Math.round(
+    (Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()) -
+      Date.UTC(target.getFullYear(), target.getMonth(), target.getDate())) /
+      MS_PER_DAY,
   )
 
   if (diffDays === 0) return 'Today'

--- a/web-app/src/routes/settings/providers/__tests__/index.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/index.test.tsx
@@ -71,6 +71,7 @@ vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog">{children}</div>,
   DialogClose: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-close">{children}</div>,
   DialogContent: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-content">{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p data-testid="dialog-description">{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-footer">{children}</div>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-header">{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-title">{children}</div>,


### PR DESCRIPTION
## Summary
- **Fix DST bug in `getDateGroup()`**: Millisecond-based day diff was off-by-one across DST boundaries (e.g. 31 days ago reported as "This Month" instead of "Older"). Switched to UTC date math.
- **Add missing `DialogDescription` mock** to 8 test files (96 test failures): the component was added to production dialog code but never added to test mocks.
- **Remove `DropdownMenuPortal` test**: component was removed from `dropdown-menu.tsx` in PR #366 but its test remained.

## Test plan
- [x] All 3,749 tests pass locally (0 failures, up from 98 failures)
- [x] `make lint` passes with 0 errors
- [ ] CI passes